### PR TITLE
Additional Edit button to edit note.

### DIFF
--- a/client/app/board/board.js
+++ b/client/app/board/board.js
@@ -91,6 +91,11 @@ Template.board.events({
         event.preventDefault();
         return false;
     },
+    'click .edit': function(event) {
+      event.preventDefault();
+      selectedNote.set(this);
+      $('#modal').modal('show');
+    },
     'click .vote': function(event) {
         event.stopPropagation();
         let username = localStorage.getItem('username');

--- a/client/app/board/notes.html
+++ b/client/app/board/notes.html
@@ -3,6 +3,7 @@
     {{#if $eq ../categoryId categoryId}}
     <div class="note well {{highlight this}}">
         <button type="button" class="btn btn-link btn-xs pull-right vote {{haveVoted this}}"> {{voters.length}} <i class="glyphicon glyphicon-thumbs-up"></i></button>
+        <button type="button" class="btn btn-link btn-xs pull-right edit"><i class="glyphicon glyphicon-edit"></i></button>
         <div>
             {{text}}
         </div>


### PR DESCRIPTION
Currently edit note feature is hidden behind double click which may not be intuitive:

<img width="738" alt="Screenshot 2022-02-26 at 18 29 47" src="https://user-images.githubusercontent.com/8055131/155853380-70dd9173-c5b4-4b89-9da8-896d88f906fc.png">

Proposed Solution:
Adding an edit icon besides like button.
![edit-note-icon](https://user-images.githubusercontent.com/8055131/155853507-462ddd09-3a95-4919-bc56-cf56f1bbf78d.gif)

